### PR TITLE
Refactor to Use Mission Specific Requirement Files

### DIFF
--- a/lambda_function/Dockerfile
+++ b/lambda_function/Dockerfile
@@ -7,7 +7,11 @@ FROM ${BASE_IMAGE}
 ARG ROOT="/"
 ARG FUNCTION_DIR="/lambda_function/"
 
-COPY requirements.txt ${ROOT}
+# Set default values for requirements file
+ARG REQUIREMENTS_FILE="hermes-requirements.txt"
+
+# Copy requirements file to root directory
+COPY ${REQUIREMENTS_FILE} ${ROOT}requirements.txt 
 
 # Update pip and install setuptools
 RUN pip install --upgrade pip setuptools

--- a/lambda_function/hermes-requirements.txt
+++ b/lambda_function/hermes-requirements.txt
@@ -4,4 +4,3 @@ hermes_eea @ git+https://github.com/HERMES-SOC/hermes_eea.git
 hermes_nemisis @ git+https://github.com/HERMES-SOC/hermes_nemisis.git
 hermes_merit @ git+https://github.com/HERMES-SOC/hermes_merit.git
 cdftracker @ git+https://github.com/HERMES-SOC/CDFTracker.git
-psycopg2-binary==2.9.7

--- a/lambda_function/padre-requirements.txt
+++ b/lambda_function/padre-requirements.txt
@@ -1,0 +1,4 @@
+sdc_aws_utils @ git+https://github.com/HERMES-SOC/sdc_aws_utils.git
+padre_meddea @ git+https://github.com/PADRESat/padre_meddea.git
+padre_sharp @ git+https://github.com/PADRESat/padre_sharp.git
+cdftracker @ git+https://github.com/HERMES-SOC/CDFTracker.git


### PR DESCRIPTION
This refactors the function to use mission-specific requirements files, avoiding the need to install all instrument packages for every mission during the build. Including all instrument packages in the mission's base Docker image could lead to conflicts with development environment branches.